### PR TITLE
Append sessiond id to the urls to avoid taking session id from cookies

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Q = require("q");
+var jSessionId=null;
 
 function xhr(request) {
     var deferred = Q.defer();
@@ -11,6 +12,13 @@ function xhr(request) {
     }
 
     var isAsync = !request.synchronousCall;
+    if(jSessionId != null && jSessionId != '' && request.url.indexOf(';jsessionid='+jSessionId) == -1){
+        if(request.url.indexOf('?') != -1){
+            request.url=request.url.replace('?',';jsessionid='+jSessionId+'?');
+        }else{
+            request.url=request.url+';jsessionid='+jSessionId;
+        }
+    }
 
     xhr.open(request.method || 'GET', request.url, isAsync);
     Object.keys(request.headers || {}).forEach(function (key) {
@@ -27,6 +35,15 @@ function xhr(request) {
             }
         });
         var response = { status: xhr.status, body: xhr.responseText, headers: headers };
+        try{
+            var pBody=JSON.parse(response.body);
+            if(typeof pBody === 'object' && pBody != null && pBody.sessionId != null){
+                jSessionId=pBody.sessionId;
+            }
+            console.log(JSON.parse(response.body).sessionId);
+        }catch(error){
+            console.log('error while sending xhr request',error);
+        }
         deferred.resolve(response);
     };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@yuzu/xcop",
     "description": "An XHR Cross Origin Proxy allows you to make XHR requests to different friendly API services.",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "homepage": "https://github.com/YuzuJS/xcop",
     "author": {
         "name": "Donavon West"


### PR DESCRIPTION
The latest browsers like Chrome 80 are enforcing the usage of the "SameSite" attribute of the cookie. This has an impact on third-party applications (an application that is accessed from another application) for instance "Blackboard" is the main application and Courseware "LMS" is third party application. 
 
"SameSite" attribute has 3 values :
 
SameSite=Lax
These cookies will be not be sent for the requests to the third-party application but sent only in case of "GET" requests that change the URL in the address bar to third-party application URL.
SameSite=Strict
These cookies will not be sent for the requests to third-party applications. 
SameSite=None; Strict(None values should be Strict which means that cookies will be sent only on secure connections).
These cookies will be sent for the requests to third-party applications. 
 
When third party application creates cookies without "SameSite" attribute browsers apply default behavior to such cookies, that is "SameSite=Lax"(in case of Chrome) which means these cookies will not be sent for requests to third-party applications. Currently, our LMS doesn't use this SameSite attribute. Due to which when our LMS is launched from Blackboard, cookies created by our LMS are not sent.
 
There are some user agents, known to be incompatible with the `SameSite=None` attribute, some user agents treat such cookies as "SameSite=Strict". 

**For this problem, we are rewriting the URLs to append the sessionid so that the sessionid will not be taken from the cookies. This is the necessary change at the ILP side but in case of Courseware UI, the authentication is done based on the token. If the URLs are not rewritten to append sessionid then for each activity a new session is created at the server side it will create lots of confusion in tracking user activities. So we decided to rewrite the URLs at Courseware UI side also.** 